### PR TITLE
FileCache._all_keys always tries to use _buffer

### DIFF
--- a/fcache/cache.py
+++ b/fcache/cache.py
@@ -205,7 +205,10 @@ class FileCache(MutableMapping):
     def _all_keys(self):
         """Return a list of all encoded key names."""
         file_keys = [self._filename_to_key(fn) for fn in self._all_filenames()]
-        return set(file_keys + list(self._buffer))
+        if self._sync:
+            return set(file_keys)
+        else:
+            return set(file_keys + list(self._buffer))
 
     def _write_to_file(self, filename, bytesvalue):
         """Write bytesvalue to filename."""

--- a/fcache/tests/test_cache.py
+++ b/fcache/tests/test_cache.py
@@ -78,6 +78,8 @@ class TestFileCache(unittest.TestCase):
         self.cache['foo'] = b'value'
         self.assertTrue(os.path.exists(self.cache._key_to_filename(
             self.cache._encode_key('foo'))))
+        self.assertTrue('foo' in self.cache)
+
 
     def test_close(self):
         self.cache.close()


### PR DESCRIPTION
Hi,
thanks for your nice library.

I had a small problem when I enabled sync mode. `FileCache._all_keys()` will always try to use the `_buffer` instance variable, but `_buffer` is only available when sync is off. The methods `__contains__()` and `__iter__()` internally use `_all_keys()` and thus fail with sync turned on. My commit fixes the problem and adds a simple assertion to the tests that would have caught the problem.
