### PR TITLE
exclude tests from dist & wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     keywords=['cache', 'file', 'serialize'],
-    packages=['fcache', 'tests'],
+    packages=['fcache'],
     test_suite='tests',
     install_requires=['appdirs'],
 )


### PR DESCRIPTION
Is there any specific reason to add tests in the package?
Installing this currently installs a "tests" package to site-packages, which causes issues for running unit-tests locally in projects that using the lib.