### PR TITLE
Use shutil.move instead of os.rename which is unable to move file between disks

### DIFF
--- a/fcache/posixemulation.py
+++ b/fcache/posixemulation.py
@@ -92,13 +92,13 @@ if os.name == 'nt':  # pragma: no cover
             return
         # Fall back to "move away and replace"
         try:
-            os.rename(src, dst)
+            shutil.move(src, dst)
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
             old = "%s-%08x" % (dst, random.randint(0, sys.maxint))
-            os.rename(dst, old)
-            os.rename(src, dst)
+            shutil.move(dst, old)
+            shutil.move(src, dst)
             try:
                 os.unlink(old)
             except Exception:


### PR DESCRIPTION
This will prevent this exception when moving a file from a disk to another:

`OSError: [WinError 17] The system cannot move the file to a different disk drive`