### PR TITLE
Use `exist_ok=False` for os.makedirs

### DIFF
--- a/src/fcache/cache.py
+++ b/src/fcache/cache.py
@@ -139,7 +139,7 @@ class FileCache(MutableMapping):
         """Create the write buffer and cache directory."""
         if not self._sync and not hasattr(self, "_buffer"):
             self._buffer = {}
-            os.makedirs(self.cache_dir, exist_ok=False)
+            os.makedirs(self.cache_dir, exist_ok=True)
 
     def clear(self):
         """Remove all items from the write buffer and cache.

--- a/src/fcache/cache.py
+++ b/src/fcache/cache.py
@@ -139,8 +139,7 @@ class FileCache(MutableMapping):
         """Create the write buffer and cache directory."""
         if not self._sync and not hasattr(self, "_buffer"):
             self._buffer = {}
-        if not os.path.exists(self.cache_dir):
-            os.makedirs(self.cache_dir)
+            os.makedirs(self.cache_dir, exist_ok=False)
 
     def clear(self):
         """Remove all items from the write buffer and cache.

--- a/src/fcache/cache.py
+++ b/src/fcache/cache.py
@@ -139,7 +139,7 @@ class FileCache(MutableMapping):
         """Create the write buffer and cache directory."""
         if not self._sync and not hasattr(self, "_buffer"):
             self._buffer = {}
-            os.makedirs(self.cache_dir, exist_ok=True)
+        os.makedirs(self.cache_dir, exist_ok=True)
 
     def clear(self):
         """Remove all items from the write buffer and cache.


### PR DESCRIPTION
https://docs.python.org/3/library/os.html#os.makedirs

We receive `FileExistsError` when multiple processes use the same file cache