### PR TITLE
Allow multiple processes to safely call `delete()` at the same time

### DIFF
--- a/src/fcache/cache.py
+++ b/src/fcache/cache.py
@@ -155,7 +155,8 @@ class FileCache(MutableMapping):
         if not self._sync:
             del self._buffer
 
-        # Allow multiple processes to delete() at the same time, meaning some or all of cache_dir may already be deleted
+        # Allow multiple processes to delete() at the same time,
+        # meaning some or all of cache_dir may already be deleted
         def _on_error(function, path, excinfo):
             if excinfo[0] != FileNotFoundError:
                 raise


### PR DESCRIPTION
Addresses https://github.com/tsroten/fcache/issues/42

This PR allows `rmtree()` to keep moving if it encounters a `FileNotFoundError` but to still fail if it runs into any other type of error (e.g. `PermissionError`)